### PR TITLE
Fix `walk_dir` return value (really closes #1)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ fn walk_dir(dir_path: &Path) -> bool {
                                 result &= check_urls(&urls);
                             }
                         } else {
-                            walk_dir(&entry.path());
+                            result &= walk_dir(&entry.path());
                         }
                     },
                     Err(err) => {


### PR DESCRIPTION
Unfortunately, I made one mistake in #10 pull request. :sweat_smile: 