### PR TITLE
Improve display of findings

### DIFF
--- a/tests/simple_project/src/lib.rs
+++ b/tests/simple_project/src/lib.rs
@@ -6,6 +6,8 @@ pub fn foo() {}
 /// Bar function
 pub fn bar() {}
 
+/// [Correct link](crate::bar)
+pub struct Tmp {}
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
Closes https://github.com/deadlinks/cargo-deadlinks/issues/19.

I did a bit more, now the output looks like

> struct.InlineString.html: Linked file primitive.char.html does not exist!
> struct.InlineString.html: Linked file iter/trait.DoubleEndedIterator.html does not exist!
> struct.InlineString.html: Linked file primitive.char.html does not exist!
> struct.InlineString.html: Linked file iter/trait.DoubleEndedIterator.html does not exist!
> struct.InlineString.html: Linked file primitive.char.html does not exist!
> struct.InlineString.html: Linked file primitive.char.html does not exist!
> struct.InlineString.html: Linked file primitive.char.html does not exist!
> struct.InlineString.html: Linked file primitive.char.html does not exist!
> struct.InlineString.html: Linked file primitive.char.html does not exist!
> struct.InlineString.html: Linked file iter/trait.DoubleEndedIterator.html does not exist!
> struct.InlineString.html: Linked file primitive.char.html does not exist!
> struct.InlineString.html: Linked file primitive.char.html does not exist!

As you requested, I left the verbose output with the long file names. It's even longer now that I've added the origin of the checked link, but imho that's useful. You don't implement checking http urls, so I wasn't sure how to handle those things for http checking, so I stayed with simply passing along pathes.

I refrained from running rustfmt on it or doing any formatting on my own, so this can be reviewed more easily. Let me know if that floats your boat :)