### PR TITLE
feat(error): improve error message for missing target doc directory

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,15 @@ fn main() {
         .arg_directory
         .clone()
         .map_or_else(determine_dir, |dir| PathBuf::from(dir));
-    let dir = dir.canonicalize().unwrap();
+    let dir = match dir.canonicalize() {
+        Ok(dir) => dir,
+        Err(_) => {
+            println!("Could not find directory {:?}.", dir);
+            println!("");
+            println!("Please run `cargo doc` before running `cargo deadlinks`.");
+            process::exit(1);
+        }
+    };
     let ctx: CheckContext = args.into();
     if !walk_dir(&dir, &ctx) {
         process::exit(1);


### PR DESCRIPTION
Old error:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', libcore/result.rs:1009:5
```

New error:
```
Could not find directory "target/doc/svgcleaner".

Please run `cargo doc` before running `cargo deadlinks`.
```