### PR TITLE
Fix compilation error.

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -16,12 +16,12 @@ pub fn parse_html_file(path: &Path) -> HashSet<Url> {
 
     let base_url = Url::from_file_path(path).unwrap();
     let mut urls = HashSet::new();
-    parse_a_hrefs(dom.document, &base_url, &mut urls);
+    parse_a_hrefs(&dom.document, &base_url, &mut urls);
     urls
 }
 
 /// Traverse the DOM of a parsed HTML element, extracting all URLs from <a href="xxx"> links.
-fn parse_a_hrefs(handle: Handle, base_url: &Url, urls: &mut HashSet<Url>) {
+fn parse_a_hrefs(handle: &Handle, base_url: &Url, urls: &mut HashSet<Url>) {
     let node = handle;
     if let NodeData::Element {
         ref name,
@@ -47,6 +47,6 @@ fn parse_a_hrefs(handle: Handle, base_url: &Url, urls: &mut HashSet<Url>) {
     }
 
     for child in node.children.borrow().iter() {
-        parse_a_hrefs(child.clone(), base_url, urls);
+        parse_a_hrefs(&child, base_url, urls);
     }
 }


### PR DESCRIPTION
This fixes a compilation error:

```text
error[E0509]: cannot move out of type `html5ever::rcdom::RcDom`, which implements the `Drop` trait
  --> /home/travis/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-deadlinks-0.4.1/src/parse.rs:19:19
   |
19 |     parse_a_hrefs(dom.document, &base_url, &mut urls);
   |                   ^^^^^^^^^^^^ cannot move out of here
```

Also, can we get a release after this lands? :)