### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,21 +11,21 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cargo_metadata = "0.6.4"
-docopt = "0.8"
-env_logger = "0.3"
-html5ever = "0.22"
-log = "0.3"
-num_cpus = "1.8"
-rayon = "1.0"
-reqwest = "0.9"
-serde = "1.0"
-serde_derive = "1.0"
-url = "1.6"
-walkdir = "2.1"
+cargo_metadata = "0.11.1"
+docopt = "1.1.0"
+env_logger = "0.7.1"
+html5ever = "0.22.0"
+log = "0.4.11"
+num_cpus = "1.13.0"
+rayon = "1.4.0"
+reqwest = { version = "0.10.8", features = ["blocking"] }
+serde = "1.0.115"
+serde_derive = "1.0.115"
+url = "2.1.1"
+walkdir = "2.3.1"
 
-clippy = { version = "0.0.186", optional = true }
-serde_json = "1.0.34"
+clippy = { version = "0.0.302", optional = true }
+serde_json = "1.0.57"
 
 [features]
 default = []
@@ -35,5 +35,5 @@ travis = []
 lint = ["clippy"]
 
 [dev-dependencies]
-assert_cmd = "0.11.0"
-predicates = "1.0.0"
+assert_cmd = "1.0.1"
+predicates = "1.0.5"

--- a/src/check.rs
+++ b/src/check.rs
@@ -91,7 +91,7 @@ fn check_http_url(url: &Url, ctx: &CheckContext) -> Result<(), CheckError> {
         }
     }
 
-    let resp = reqwest::get(url.as_str());
+    let resp = reqwest::blocking::get(url.as_str());
     match resp {
         Ok(r) => {
             if r.status() == StatusCode::OK {


### PR DESCRIPTION
This takes the number of dependencies down from ~270 to ~215.
I did not update HTML5ever because it removed RcDom in 0.25, and switching to kuchiki would have required a rewrite of the code.

Addresses https://github.com/deadlinks/cargo-deadlinks/issues/46