### PR TITLE
Use http HEAD method request instead of GET

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -91,7 +91,7 @@ fn check_http_url(url: &Url, ctx: &CheckContext) -> Result<(), CheckError> {
         }
     }
 
-    let resp = reqwest::blocking::get(url.as_str());
+    let resp = reqwest::blocking::Client::new().head(url.as_str()).send();
     match resp {
         Ok(r) => {
             if r.status() == StatusCode::OK {


### PR DESCRIPTION
Are there any downsides to use HEAD?

According to https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html:

> This method is often used for testing hypertext links for validity, accessibility, and recent modification.