### PR TITLE
Take CARGO_TARGET_DIR into account

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,7 @@ fn determine_dir() -> PathBuf {
                 .unwrap();
             let package_name = package_name.replace("-", "_");
 
-            Path::new("target").join("doc").join(package_name)
+            manifest.target_directory.join("doc").join(package_name)
         }
         Err(_) => {
             error!("Could not find a Cargo.toml.");

--- a/tests/simple_project.rs
+++ b/tests/simple_project.rs
@@ -8,11 +8,8 @@ use std::process::Command;
 mod simple_project {
     use super::*;
 
-    #[test]
-    #[allow(unused_must_use)]
-    fn it_checks_okay_project_correctly() {
-        // cargo-deadlinks fails when docs have not been generated before
-        match std::fs::remove_dir_all("./tests/simple_project/target") {
+    fn remove_all(path: &str) {
+        match std::fs::remove_dir_all(path) {
             Ok(_) => {}
             Err(err) => match err.kind() {
                 std::io::ErrorKind::NotFound => {}
@@ -22,19 +19,9 @@ mod simple_project {
                 ),
             },
         };
-        Command::cargo_bin("cargo-deadlinks")
-            .unwrap()
-            .arg("deadlinks")
-            .current_dir("./tests/simple_project")
-            .assert()
-            .failure()
-            .stdout(predicate::str::contains(
-                "Could not find directory \"target/doc/simple_project\".",
-            ))
-            .stdout(predicate::str::contains(
-                "Please run `cargo doc` before running `cargo deadlinks`.",
-            ));
+    }
 
+    fn assert_doc() -> assert_cmd::assert::Assert {
         // generate docs
         Command::new("cargo")
             .arg("doc")
@@ -48,6 +35,42 @@ mod simple_project {
             .arg("deadlinks")
             .current_dir("./tests/simple_project")
             .assert()
-            .success();
+    }
+
+    #[test]
+    fn it_checks_okay_project_correctly() {
+        use predicate::str::contains;
+
+        std::env::remove_var("CARGO_TARGET_DIR");
+
+        // cargo-deadlinks fails when docs have not been generated before
+        remove_all("./tests/simple_project/target");
+
+        Command::cargo_bin("cargo-deadlinks")
+            .unwrap()
+            .arg("deadlinks")
+            .current_dir("./tests/simple_project")
+            .assert()
+            .failure()
+            .stdout(
+                contains("Could not find directory")
+                    .and(contains("target/doc/simple_project\"."))
+                    .and(contains(
+                        "Please run `cargo doc` before running `cargo deadlinks`.",
+                    )),
+            );
+
+        assert_doc().success();
+
+        // NOTE: can't be parallel because of use of `set_var`
+        std::env::set_var("CARGO_TARGET_DIR", "target2");
+        remove_all("./tests/simple_project/target2");
+        assert_doc().success();
+
+        std::env::remove_var("CARGO_TARGET_DIR");
+        std::env::set_var("CARGO_BUILD_TARGET", "x86_64-unknown-linux-gnu");
+        remove_all("./tests/simple_project/target");
+        // This currently breaks due to a cargo bug: https://github.com/rust-lang/cargo/issues/8791
+        assert_doc().failure();
     }
 }


### PR DESCRIPTION
This fixes one of the problems mentioned in https://github.com/deadlinks/cargo-deadlinks/issues/38, but not the other - `cargo metadata` doesn't take `CARGO_BUILD_DIR` into account either. IMO that should be an upstream cargo fix (https://github.com/rust-lang/cargo/issues/8791).