### PR TITLE
Follow target renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Take `CARGO_TARGET_DIR` into account when looking for the target directory. [PR#66]
 * Give a better error message if Cargo.toml is not present. [PR#67]
+* Follow target renames. [PR#68]
 
 [PR#66]: https://github.com/deadlinks/cargo-deadlinks/pull/66
 [PR#67]: https://github.com/deadlinks/cargo-deadlinks/pull/67
@@ -13,10 +14,12 @@
 
 * Update dependencies. [PR#51] Thanks to [@Marwes][user_marwes]!
 * Use HEAD instead of GET for HTTP requests. This should decrease the time for HTTP checks slightly. [PR#63] Thanks to [@zummenix]!
+* Check all targets, not just targets with the same name as the package. In particular, this now checks both binaries and libraries. [PR#68]
 
 [@zummenix]: https://github.com/zummenix
 [PR#51]: https://github.com/deadlinks/cargo-deadlinks/pull/51
 [PR#63]: https://github.com/deadlinks/cargo-deadlinks/pull/63
+[PR#68]: https://github.com/deadlinks/cargo-deadlinks/pull/68
 
 <a name="0.4.1"></a>
 ## 0.4.1 (2019-03-26)

--- a/tests/renamed_package/Cargo.toml
+++ b/tests/renamed_package/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "renamed_package"
+version = "0.1.0"
+authors = ["Joshua Nelson <jyn514@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "x"
+path = "src/main.rs"
+
+[dependencies]

--- a/tests/renamed_package/src/main.rs
+++ b/tests/renamed_package/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/tests/simple_project.rs
+++ b/tests/simple_project.rs
@@ -5,39 +5,42 @@ use assert_cmd::prelude::*;
 use predicate::str::contains;
 use predicates::prelude::*;
 use std::env;
+use std::path::Path;
 use std::process::Command;
+
+fn remove_all(path: &str) {
+    match std::fs::remove_dir_all(path) {
+        Ok(_) => {}
+        Err(err) => match err.kind() {
+            std::io::ErrorKind::NotFound => {}
+            _ => panic!(
+                "Unexpected error when trying do remove target directory: {:?}",
+                err
+            ),
+        },
+    };
+}
+
+fn assert_doc(dir: impl AsRef<Path>) -> assert_cmd::assert::Assert {
+    let dir = dir.as_ref();
+
+    // generate docs
+    Command::new("cargo")
+        .arg("doc")
+        .current_dir(dir)
+        .assert()
+        .success();
+
+    // succeeds with generated docs
+    Command::cargo_bin("cargo-deadlinks")
+        .unwrap()
+        .arg("deadlinks")
+        .current_dir(dir)
+        .assert()
+}
 
 mod simple_project {
     use super::*;
-
-    fn remove_all(path: &str) {
-        match std::fs::remove_dir_all(path) {
-            Ok(_) => {}
-            Err(err) => match err.kind() {
-                std::io::ErrorKind::NotFound => {}
-                _ => panic!(
-                    "Unexpected error when trying do remove target directory: {:?}",
-                    err
-                ),
-            },
-        };
-    }
-
-    fn assert_doc() -> assert_cmd::assert::Assert {
-        // generate docs
-        Command::new("cargo")
-            .arg("doc")
-            .current_dir("./tests/simple_project")
-            .assert()
-            .success();
-
-        // succeeds with generated docs
-        Command::cargo_bin("cargo-deadlinks")
-            .unwrap()
-            .arg("deadlinks")
-            .current_dir("./tests/simple_project")
-            .assert()
-    }
 
     #[test]
     fn it_gives_help_if_cargo_toml_missing() {
@@ -74,17 +77,27 @@ mod simple_project {
                     )),
             );
 
-        assert_doc().success();
+        assert_doc("./tests/simple_project").success();
 
         // NOTE: can't be parallel because of use of `set_var`
         env::set_var("CARGO_TARGET_DIR", "target2");
         remove_all("./tests/simple_project/target2");
-        assert_doc().success();
+        assert_doc("./tests/simple_project").success();
 
         env::remove_var("CARGO_TARGET_DIR");
         env::set_var("CARGO_BUILD_TARGET", "x86_64-unknown-linux-gnu");
         remove_all("./tests/simple_project/target");
         // This currently breaks due to a cargo bug: https://github.com/rust-lang/cargo/issues/8791
-        assert_doc().failure();
+        assert_doc("./tests/simple_project").failure();
+    }
+}
+
+mod renamed_project {
+    use super::*;
+
+    #[test]
+    fn it_follows_package_renames() {
+        remove_all("./tests/renamed_package/target");
+        assert_doc("./tests/renamed_package");
     }
 }


### PR DESCRIPTION
Closes https://github.com/deadlinks/cargo-deadlinks/issues/21.

Targets are not unique within a package, so this required checking all applicable targets.