### PR TITLE
Fix test collisions when using a shared CARGO_TARGET_DIR

### DIFF
--- a/tests/non_existent_http_link/Cargo.toml
+++ b/tests/non_existent_http_link/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "simple_project"
+name = "non_existent_http_link"
 version = "0.1.0"
 authors = ["Maximilian Goisser <goisser94@gmail.com>"]
 edition = "2018"

--- a/tests/working_http_check/Cargo.toml
+++ b/tests/working_http_check/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "simple_project"
+name = "working_http_check"
 version = "0.1.0"
 authors = ["Maximilian Goisser <goisser94@gmail.com>"]
 edition = "2018"


### PR DESCRIPTION
These would cause spurious failures like

````
---- working_http_check::works stdout ----
thread 'working_http_check::works' panicked at 'Unexpected failure.
code-1
stderr=```Found invalid urls in /home/joshua/.local/lib/cargo/target/doc/simple_project/fn.foo.html:
	Error fetching http://thiswebsitedoesnotexist.xyz/: error sending request for url (http://thiswebsitedoesnotexist.xyz/): error trying to connect: dns error: failed to lookup address information: Name or service not known
```
command=`"/home/joshua/.local/lib/cargo/target/debug/cargo-deadlinks" "deadlinks" "--check-http"`
code=1
stdout=``````
stderr=```Found invalid urls in /home/joshua/.local/lib/cargo/target/doc/simple_project/fn.foo.html:
	Error fetching http://thiswebsitedoesnotexist.xyz/: error sending request for url (http://thiswebsitedoesnotexist.xyz/): error trying to connect: dns error: failed to lookup address information: Name or service not known
````

This is because the same `simple_project` name was used for each test;
if they were used with a shared target directory, the files would be
overwritten. This uses a different name for each test to avoid
conflicts.