### PR TITLE
Fix packages with dashes instead of underscores

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -162,7 +162,7 @@ fn determine_dir() -> Vec<PathBuf> {
         .map(|package| package.targets)
         .flatten()
         .filter(|target| target.kind.iter().all(|kind| kind != "test"))
-        .map(|target| doc.join(target.name))
+        .map(|target| doc.join(target.name.replace('-', "_")))
         .collect()
 }
 

--- a/tests/renamed_package/Cargo.toml
+++ b/tests/renamed_package/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]
-name = "x"
+name = "renamed-package-x"
 path = "src/main.rs"
 
 [dependencies]


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/deadlinks/cargo-deadlinks/pull/68 and adds a test.