### PR TITLE
Various bugfixes and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <a name="unreleased"></a>
 ## NEXT (UNRELEASED)
 
+#### Added
+
+* Add support for cargo workspaces. Check all crates and targets in the workspaces, excluding tests, benches, and examples. [PR#68], [PR#73]
+
 #### Fixes
 
 * Take `CARGO_TARGET_DIR` into account when looking for the target directory. [PR#66]
@@ -9,6 +13,7 @@
 
 [PR#66]: https://github.com/deadlinks/cargo-deadlinks/pull/66
 [PR#67]: https://github.com/deadlinks/cargo-deadlinks/pull/67
+[PR#73]: https://github.com/deadlinks/cargo-deadlinks/pull/73
 
 #### Changes
 

--- a/tests/simple_project.rs
+++ b/tests/simple_project.rs
@@ -104,3 +104,13 @@ mod renamed_project {
         assert_doc("./tests/renamed_package", &[]).success();
     }
 }
+
+mod workspace {
+    use super::*;
+
+    #[test]
+    fn it_checks_workspaces() {
+        remove_all("./tests/workspace/target");
+        assert_doc("./tests/workspace", &[]).success();
+    }
+}

--- a/tests/workspace/Cargo.toml
+++ b/tests/workspace/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["a", "b"]

--- a/tests/workspace/a/Cargo.toml
+++ b/tests/workspace/a/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "a"
+version = "0.1.0"
+authors = ["Joshua Nelson <jyn514@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/workspace/a/src/lib.rs
+++ b/tests/workspace/a/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/tests/workspace/b/Cargo.toml
+++ b/tests/workspace/b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "b"
+version = "0.1.0"
+authors = ["Joshua Nelson <jyn514@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/workspace/b/src/lib.rs
+++ b/tests/workspace/b/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
- Add a test for workspaces

  This was implemented in https://github.com/deadlinks/cargo-deadlinks/pull/68,
  although I didn't realize it at the time.

- Don't try to document benches, examples, and tests

  `cargo doc` does not document these targets, so there will be no
  corresponding doc directory.

- Don't exit on the first target that fails; instead check all targets.

Closes https://github.com/deadlinks/cargo-deadlinks/issues/9.