### PR TITLE
Always output all errors instead of stopping after the first error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@
 * Take `CARGO_TARGET_DIR` into account when looking for the target directory. [PR#66]
 * Give a better error message if Cargo.toml is not present. [PR#67]
 * Follow target renames. [PR#68]
+* Always output all errors instead of stopping after the first error. [PR#74]
+
+  Previously, deadlinks would stop after the first error, but leave other threads running in parallel. This would lead to non-deterministic and incomplete output if there were broken links in many different files.
+  Deadlinks will now output all errors before exiting.
 
 [PR#66]: https://github.com/deadlinks/cargo-deadlinks/pull/66
 [PR#67]: https://github.com/deadlinks/cargo-deadlinks/pull/67
 [PR#73]: https://github.com/deadlinks/cargo-deadlinks/pull/73
+[PR#74]: https://github.com/deadlinks/cargo-deadlinks/pull/74
 
 #### Changes
 


### PR DESCRIPTION
@martin-t can you confirm that this fixes your issue with non-deterministic output? I can't reproduce your issue locally.

Hopefully closes https://github.com/deadlinks/cargo-deadlinks/issues/56.