### PR TITLE
Update some more dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 cargo_metadata = "0.9"
 docopt = "1"
-env_logger = "0.7"
+env_logger = "0.8"
 html5ever = "0.24"
 log = "0.4"
 num_cpus = "1.8"
@@ -23,5 +23,5 @@ walkdir = "2.1"
 serde_json = "1.0.34"
 
 [dev-dependencies]
-assert_cmd = "0.12.0"
+assert_cmd = "1.0"
 predicates = "1.0.0"


### PR DESCRIPTION
This doesn't yet update cargo_metadata because it added 8 more
dependencies since 0.9.