### PR TITLE
[WIP] deploy to crates.io automatically

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,16 @@ on:
       - '*'
 
 jobs:
-  publish:
+  crates_io:
+    name: Publish deadlinks to crates.io
+    steps:
+      - uses: actions/checkout@v1
+      - run: cargo login ${CRATES_IO_TOKEN}
+        env:
+          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      - run: cargo publish
+
+  github:
     name: Publish deadlinks for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
This won't work until I added `CRATES_IO_TOKEN` to the repo secrets, which I'm not sure about ... @kixiron what do you think?

Either way, I don't plan to use this until I _actually_ make a release, so after https://github.com/deadlinks/cargo-deadlinks/pull/74.