### PR TITLE
Remove CheckContext struct, put args into the lib

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -4,7 +4,7 @@ use std::{fmt, path::PathBuf};
 use reqwest::{self, StatusCode};
 use url::Url;
 
-use super::CheckContext;
+use crate::MainArgs;
 
 const PREFIX_BLACKLIST: [&str; 1] = ["https://doc.rust-lang.org"];
 
@@ -43,7 +43,7 @@ impl fmt::Display for CheckError {
 }
 
 /// Check a single URL for availability. Returns `false` if it is unavailable.
-pub fn is_available(url: &Url, ctx: &CheckContext) -> Result<(), CheckError> {
+pub(crate) fn is_available(url: &Url, ctx: &MainArgs) -> Result<(), CheckError> {
     match url.scheme() {
         "file" => check_file_url(url, ctx),
         "http" | "https" => check_http_url(url, ctx),
@@ -59,7 +59,7 @@ pub fn is_available(url: &Url, ctx: &CheckContext) -> Result<(), CheckError> {
 }
 
 /// Check a URL with the "file" scheme for availability. Returns `false` if it is unavailable.
-fn check_file_url(url: &Url, _ctx: &CheckContext) -> Result<(), CheckError> {
+fn check_file_url(url: &Url, _args: &MainArgs) -> Result<(), CheckError> {
     let path = url.to_file_path().unwrap();
 
     if path.exists() {
@@ -72,8 +72,8 @@ fn check_file_url(url: &Url, _ctx: &CheckContext) -> Result<(), CheckError> {
 }
 
 /// Check a URL with "http" or "https" scheme for availability. Returns `false` if it is unavailable.
-fn check_http_url(url: &Url, ctx: &CheckContext) -> Result<(), CheckError> {
-    if !ctx.check_http {
+fn check_http_url(url: &Url, args: &MainArgs) -> Result<(), CheckError> {
+    if !args.flag_check_http {
         debug!(
             "Skip checking {} as checking of http URLs is turned off",
             url

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ extern crate log;
 extern crate html5ever;
 extern crate url;
 
+#[macro_use]
+extern crate serde_derive;
+
 extern crate cargo_metadata;
 extern crate num_cpus;
 extern crate rayon;
@@ -29,9 +32,12 @@ pub use check::{CheckError, HttpError};
 mod check;
 mod parse;
 
-#[derive(Debug)]
-pub struct CheckContext {
-    pub check_http: bool,
+#[derive(Debug, Deserialize)]
+pub struct MainArgs {
+    pub arg_directory: Option<String>,
+    pub flag_verbose: bool,
+    pub flag_debug: bool,
+    pub flag_check_http: bool,
 }
 
 #[derive(Debug)]
@@ -60,7 +66,7 @@ fn is_html_file(entry: &DirEntry) -> bool {
 
 pub fn unavailable_urls<'a>(
     dir_path: &'a Path,
-    ctx: &'a CheckContext,
+    ctx: &'a MainArgs,
 ) -> impl ParallelIterator<Item = FileError> + 'a {
     WalkDir::new(dir_path)
         .into_iter()


### PR DESCRIPTION
When working on rebasing https://github.com/deadlinks/cargo-deadlinks/pull/20 I found this.  I don't really see why one would want `CheckContext` to exist. It's not a performance optimization (we're passing along a reference to a struct no matter what), we need an additional step for conversion, and we pass along less information after all. I'll need more detailed command line args information for https://github.com/deadlinks/cargo-deadlinks/pull/20, so I figured I could just enlargen` CheckContext`... but what's the point really? Lets stick to one argument struct which we'll pass read-only along the chain, I'd say.