### PR TITLE
Split cargo-deadlinks and deadlinks into two binaries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,16 +16,16 @@ jobs:
         include:
           - name: linux
             os: ubuntu-latest
-            artifact_name: cargo-deadlinks
-            asset_name: deadlinks-linux
+            suffix: ""
+            asset_suffix: -linux
           - name: windows
             os: windows-latest
-            artifact_name: cargo-deadlinks.exe
-            asset_name: deadlinks-windows
+            suffix: .exe
+            asset_suffix: -windows
           - name: macos
             os: macos-latest
-            artifact_name: cargo-deadlinks
-            asset_name: deadlinks-macos
+            suffix: ""
+            asset_suffix: -macos
 
     steps:
       - uses: actions/checkout@v1
@@ -38,10 +38,18 @@ jobs:
       - name: Build
         run: cargo build --release
 
-      - name: Upload binaries to release
+      - name: Upload `deadlinks` binaries
         uses: svenstaro/upload-release-action@v1-release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/release/${{ matrix.artifact_name }}
-          asset_name: ${{ matrix.asset_name }}
+          file: target/release/deadlinks${{ matrix.suffix }}
+          asset_name: deadlinks${{ matrix.asset_suffix }}
+          tag: ${{ github.ref }}
+
+      - name: Upload `cargo-deadlinks` binaries
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/release/cargo-deadlinks${{ matrix.suffix }}
+          asset_name: cargo-deadlinks${{ matrix.asset_suffix }}
           tag: ${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Added
 
 * `RUST_LOG` is now read, and controls logging. [PR#100]
+* There is now a separate `deadlinks` binary which doesn't depend on cargo in any way. [PR#87]
 
 #### Changes
 
@@ -12,6 +13,7 @@
 * Logging now follows the standard `env_logger` format. [PR#100]
 * `--debug` and `--verbose` are deprecated in favor of `RUST_LOG`. [PR#100]
 
+[PR#87]: https://github.com/deadlinks/cargo-deadlinks/pull/87
 [PR#100]: https://github.com/deadlinks/cargo-deadlinks/pull/100
 
 <a name="0.5.0"></a>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/deadlinks/cargo-deadlinks"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 autobins = false
+default-run = "deadlinks"
 
 [[bin]]
 name = "cargo-deadlinks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,22 @@ edition = "2018"
 repository = "https://github.com/deadlinks/cargo-deadlinks"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
+autobins = false
+
+[[bin]]
+name = "cargo-deadlinks"
+required-features = ["cargo"]
+
+[[bin]]
+name = "deadlinks"
+
+[features]
+cargo = ["cargo_metadata", "serde_json"]
+default = ["cargo"]
 
 [dependencies]
-cargo_metadata = "0.9"
+cargo_metadata = { version = "0.9", optional = true }
+serde_json = { version = "1.0.34", optional = true }
 docopt = "1"
 env_logger = "0.8"
 lol_html = "0.2"
@@ -21,7 +34,6 @@ serde = "1.0"
 serde_derive = "1.0"
 url = "2"
 walkdir = "2.1"
-serde_json = "1.0.34"
 
 [dev-dependencies]
 assert_cmd = "1.0"

--- a/src/bin/deadlinks.rs
+++ b/src/bin/deadlinks.rs
@@ -1,0 +1,61 @@
+use std::path::PathBuf;
+use std::process;
+
+use cargo_deadlinks::{walk_dir, CheckContext};
+use docopt::Docopt;
+use serde_derive::Deserialize;
+
+mod shared;
+
+const MAIN_USAGE: &str = "
+Check your package's documentation for dead links.
+
+Usage:
+    deadlinks <directory> [options]
+
+Options:
+    -h --help               Print this message
+    --check-http            Check 'http' and 'https' scheme links
+    --debug                 Use debug output
+    -v --verbose            Use verbose output
+    -V --version            Print version info and exit.
+";
+
+#[derive(Debug, Deserialize)]
+struct MainArgs {
+    arg_directory: PathBuf,
+    flag_verbose: bool,
+    flag_debug: bool,
+    flag_check_http: bool,
+}
+
+impl From<MainArgs> for CheckContext {
+    fn from(args: MainArgs) -> CheckContext {
+        CheckContext {
+            check_http: args.flag_check_http,
+            verbose: args.flag_debug,
+        }
+    }
+}
+
+fn main() {
+    let args: MainArgs = Docopt::new(MAIN_USAGE)
+        .and_then(|d| {
+            d.version(Some(env!("CARGO_PKG_VERSION").to_owned()))
+                .deserialize()
+        })
+        .unwrap_or_else(|e| e.exit());
+    shared::init_logger(args.flag_debug, args.flag_verbose, "deadlinks");
+
+    let dir = match args.arg_directory.canonicalize() {
+        Ok(dir) => dir,
+        Err(_) => {
+            println!("Could not find directory {:?}.", args.arg_directory);
+            process::exit(1);
+        }
+    };
+    log::info!("checking directory {:?}", dir);
+    if walk_dir(&dir, args.into()) {
+        process::exit(1);
+    }
+}

--- a/src/bin/shared.rs
+++ b/src/bin/shared.rs
@@ -1,0 +1,16 @@
+use log::LevelFilter;
+
+/// Initalizes the logger according to the provided config flags.
+pub fn init_logger(debug: bool, verbose: bool, krate: &str) {
+    let mut builder = env_logger::Builder::new();
+    match (debug, verbose) {
+        (true, _) => {
+            builder.filter(Some(krate), LevelFilter::Debug);
+        }
+        (false, true) => {
+            builder.filter(Some(krate), LevelFilter::Info);
+        }
+        _ => {}
+    }
+    builder.parse_default_env().init();
+}

--- a/src/check.rs
+++ b/src/check.rs
@@ -120,7 +120,14 @@ mod test {
         let cwd = env::current_dir().unwrap();
         let url = Url::from_file_path(cwd.join(path)).unwrap();
 
-        check_file_url(&url, &CheckContext { check_http: false }).unwrap();
+        check_file_url(
+            &url,
+            &CheckContext {
+                verbose: false,
+                check_http: false,
+            },
+        )
+        .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
- Expose public `walk_dir` function, which prints all missing files
- `impl Clone for CheckContext`
- Put cargo dependencies behind a feature gate
- Switch from `Into` to `From` to help type inference

Closes #47.

r? @hobofan - what do you think? Does it make sense to expose `walk_dir` publicly? If not, I can move it into `mod shared`.