### PR TITLE
Make http-checking an optional feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
           command: sweep
           args: --stamp
 
+      - name: Check features
+        run: cargo check --no-default-features
+
       - name: Build
         run: cargo build
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/deadlinks/cargo-deadlinks"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 
+[features]
+default = ["http-check"]
+http-check = ["ureq"]
+
 [dependencies]
 cargo_metadata = "0.9"
 docopt = "1"
@@ -16,7 +20,7 @@ html5ever = "0.24"
 log = "0.4"
 num_cpus = "1.8"
 rayon = "1.0"
-ureq = { version = "1.5.2", features = ["tls"], default-features = false }
+ureq = { version = "1.5.2", features = ["tls"], default-features = false, optional = true }
 serde = "1.0"
 serde_derive = "1.0"
 url = "2"

--- a/src/check.rs
+++ b/src/check.rs
@@ -6,14 +6,14 @@ use url::Url;
 
 use super::CheckContext;
 
-const PREFIX_BLACKLIST: [&str; 1] = ["https://doc.rust-lang.org"];
-
 #[derive(Debug)]
+#[cfg(feature = "http-check")]
 pub enum HttpError {
     UnexpectedStatus(Url, ureq::Response),
     Fetch(Url, ureq::Error),
 }
 
+#[cfg(feature = "http-check")]
 impl fmt::Display for HttpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -31,6 +31,7 @@ impl fmt::Display for HttpError {
 #[derive(Debug)]
 pub enum CheckError {
     File(PathBuf),
+    #[cfg(feature = "http-check")]
     Http(Box<HttpError>),
 }
 
@@ -40,6 +41,7 @@ impl fmt::Display for CheckError {
             CheckError::File(path) => {
                 write!(f, "Linked file at path {} does not exist!", path.display())
             }
+            #[cfg(feature = "http-check")]
             CheckError::Http(err) => err.fmt(f),
         }
     }
@@ -49,7 +51,17 @@ impl fmt::Display for CheckError {
 pub fn is_available(url: &Url, ctx: &CheckContext) -> Result<(), CheckError> {
     match url.scheme() {
         "file" => check_file_url(url, ctx),
-        "http" | "https" => check_http_url(url, ctx),
+        "http" | "https" => {
+            #[cfg(feature = "http-check")]
+            let res = check_http_url(url, ctx);
+            #[cfg(not(feature = "http-check"))]
+            let res = {
+                log::warn!("ignoring HTTP URL {}", url);
+                log::info!("you can enable http checking with `--features=http-check`");
+                Ok(())
+            };
+            res
+        }
         scheme @ "javascript" => {
             debug!("Not checking URL scheme {:?}", scheme);
             Ok(())
@@ -74,8 +86,11 @@ fn check_file_url(url: &Url, _ctx: &CheckContext) -> Result<(), CheckError> {
     }
 }
 
+#[cfg(feature = "http-check")]
 /// Check a URL with "http" or "https" scheme for availability. Returns `false` if it is unavailable.
 fn check_http_url(url: &Url, ctx: &CheckContext) -> Result<(), CheckError> {
+    const PREFIX_BLACKLIST: [&str; 1] = ["https://doc.rust-lang.org"];
+
     if !ctx.check_http {
         debug!(
             "Skip checking {} as checking of http URLs is turned off",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,15 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use rayon::prelude::*;
+use rayon::iter::{ParallelBridge, ParallelIterator};
 use walkdir::{DirEntry, WalkDir};
 
 use check::is_available;
 use parse::parse_html_file;
 
-pub use check::{CheckError, HttpError};
+pub use check::CheckError;
+#[cfg(feature = "http-check")]
+pub use check::HttpError;
 
 mod check;
 mod parse;
@@ -42,6 +44,7 @@ impl FileError {
             use CheckError::*;
 
             match e {
+                #[cfg(feature = "http-check")]
                 Http(_) => ret.push_str(&format!("\n\t{}", e)),
                 File(epath) => {
                     let epath = epath.strip_prefix(&prefix).unwrap_or(&epath);


### PR DESCRIPTION
Doing this for rayon requires more thought, since ParallelIterator is part of the public API.

Partially addresses https://github.com/deadlinks/cargo-deadlinks/issues/75.