### PR TITLE
feat: allow for index.html expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NEXT (UNRELEASED)
 
+#### Added
+
+* If URL is pointing to a directory check if index.html exist in that directory [PR#90]
+
 #### Fixes
 
 * No longer try to document examples that are dynamic libraries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 #### Added
 
-* If URL is pointing to a directory check if index.html exist in that directory [PR#90]
+* If a URL points to a directory, check if index.html exists in that directory. [PR#90]
+
+[PR#90]: https://github.com/deadlinks/cargo-deadlinks/pull/90
 
 #### Fixes
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -63,7 +63,7 @@ pub fn is_available(url: &Url, ctx: &CheckContext) -> Result<(), CheckError> {
 fn check_file_url(url: &Url, _ctx: &CheckContext) -> Result<(), CheckError> {
     let path = url.to_file_path().unwrap();
 
-    if path.exists() {
+    if path.is_file() || path.join("index.html").is_file() {
         debug!("Linked file at path {} does exist.", path.display());
         Ok(())
     } else {
@@ -105,5 +105,29 @@ fn check_http_url(url: &Url, ctx: &CheckContext) -> Result<(), CheckError> {
             }
         }
         Err(e) => Err(CheckError::Http(HttpError::Fetch(url.clone(), e))),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{check_file_url, CheckContext};
+    use std::env;
+    use url::Url;
+
+    fn test_check_file_url(path: &str) {
+        let cwd = env::current_dir().unwrap();
+        let url = Url::from_file_path(cwd.join(path)).unwrap();
+
+        check_file_url(&url, &CheckContext { check_http: false }).unwrap();
+    }
+
+    #[test]
+    fn test_file_path() {
+        test_check_file_url("tests/html/index.html");
+    }
+
+    #[test]
+    fn test_directory_path() {
+        test_check_file_url("tests/html/");
     }
 }

--- a/tests/html/index.html
+++ b/tests/html/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Test HTML file</title>
+    </head>
+    <body>
+        <h1>Hi there</h1>
+    </body>
+</html>


### PR DESCRIPTION
When providing links it is common to abbreviate `path/to/index.html` as
`path/to/`, i.e. to omit `index.html`. This change refines the check to
take that case into consideration: a path to be considered valid, needs
to point to a _file_ or to a _directory containing index.html_.

Existing check would check if a path exists, regardless of if that path
was pointing to a directory or to a file.