### PR TITLE
feat: handle absolute paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 #### Added
 
 * If a URL points to a directory, check if index.html exists in that directory. [PR#90]
+* Treat absolute paths as absolute with respect to the `base_url`, not with respect to the file system. [PR#91]
 
 [PR#90]: https://github.com/deadlinks/cargo-deadlinks/pull/90
+[PR#91]: https://github.com/deadlinks/cargo-deadlinks/pull/91
 
 #### Fixes
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -36,8 +36,13 @@ fn parse_a_hrefs(handle: &Handle, base_url: &Url, urls: &mut HashSet<Url>) {
                 .iter()
                 .find(|attr| &attr.name.local == "href")
             {
-                let val = &attr.value;
-                if let Ok(link) = base_url.join(val) {
+                let mut val = attr.value.clone();
+                // Treat absolute paths as absolute with respect to the `base_url`, not with respect to the file system.
+                if attr.value.starts_with('/') {
+                    val.pop_front_char();
+                }
+
+                if let Ok(link) = base_url.join(&val) {
                     debug!("link is {:?}", link);
                     urls.insert(link);
                 } else {
@@ -49,5 +54,41 @@ fn parse_a_hrefs(handle: &Handle, base_url: &Url, urls: &mut HashSet<Url>) {
 
     for child in node.children.borrow().iter() {
         parse_a_hrefs(&child, base_url, urls);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use html5ever::parse_document;
+    use html5ever::{rcdom::RcDom, tendril::TendrilSink};
+    use std::collections::HashSet;
+    use url::Url;
+
+    use super::parse_a_hrefs;
+
+    #[test]
+    fn test_parse_a_hrefs() {
+        let html = r#"
+        <!DOCTYPE html>
+        <html>
+            <body>
+                <a href="a.html">a</a>
+                <a href="/b/c.html">a</a>
+            </body>
+        </html> 
+        "#;
+
+        let dom = parse_document(RcDom::default(), Default::default())
+            .from_utf8()
+            .read_from(&mut html.as_bytes())
+            .unwrap();
+
+        let base_url = Url::from_directory_path("/base").unwrap();
+
+        let mut urls = HashSet::new();
+        parse_a_hrefs(&dom.document, &base_url, &mut urls);
+
+        assert!(urls.contains(&Url::from_file_path("/base/a.html").unwrap()));
+        assert!(urls.contains(&Url::from_file_path("/base/b/c.html").unwrap()));
     }
 }


### PR DESCRIPTION
Some `href` values might start with a `/`, denoting an absolute path and
should be considered relative to the given `dir` path. In `url::Url`
`join`-ing absolute path results in that absolute path, i.e.:

```
assert!(base.join(Url::from_file_path("/page.html").unwrap()) == "/page.html")
```

In this case deadlinks would flag `/page.html` to be broken, whereas it
could be considered valid relative to the `base` path.