### PR TITLE
Improve handling of logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## NEXT (UNRELEASED)
 
+#### Added
+
+* `RUST_LOG` is now read, and controls logging. [PR#100]
+
+#### Changes
+
+* Errors are now printed to stdout, not stderr. [PR#100]
+* Logging now follows the standard `env_logger` format. [PR#100]
+* `--debug` and `--verbose` are deprecated in favor of `RUST_LOG`. [PR#100]
+
+[PR#100]: https://github.com/deadlinks/cargo-deadlinks/pull/100
+
 <a name="0.5.0"></a>
 ## 0.5.0 (2020-11-13)
 

--- a/tests/simple_project.rs
+++ b/tests/simple_project.rs
@@ -56,7 +56,7 @@ mod simple_project {
             .current_dir(env::temp_dir())
             .assert()
             .failure()
-            .stderr(
+            .stdout(
                 contains("help: if this is not a cargo directory, use `--dir`")
                     .and(contains("error: could not find `Cargo.toml`")),
             );
@@ -103,7 +103,7 @@ mod simple_project {
             .current_dir("./tests/simple_project")
             .assert()
             .failure()
-            .stderr(
+            .stdout(
                 contains("Linked file at path fn.bar.html does not exist!")
                     .and(contains("Found invalid urls in fn.foo.html:")),
             );
@@ -114,7 +114,7 @@ mod simple_project {
             .current_dir("./tests/simple_project")
             .assert()
             .failure()
-            .stderr(
+            .stdout(
                 contains(
                     "cargo-deadlinks/tests/simple_project/ta\
                   rget/doc/simple_project/fn.foo.html:",


### PR DESCRIPTION
- Read `RUST_LOG`. Previously it was ignored.
- Print errors to stdout, not stderr. Don't go through `log` for errors.
- Don't override the logging format for `info` and `debug` level logging.
- Mark `--debug` and `--verbose` as deprecated

Closes https://github.com/deadlinks/cargo-deadlinks/issues/92.