### PR TITLE
feat: --ignore-fragments CLI parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## NEXT (UNRELEASED)
 
+#### Added
+
+ * `--ignore-fragments` CLI parameter to disable URL fagment checking [PR#108]
+
+[PR#108]: https://github.com/deadlinks/cargo-deadlinks/pull/108
+
 <a name="0.6.0"></a>
 ## 0.6.0 (2020-11-19)
 

--- a/src/bin/cargo-deadlinks.rs
+++ b/src/bin/cargo-deadlinks.rs
@@ -21,6 +21,7 @@ Options:
     -h --help               Print this message.
     --dir                   Specify a directory to check (default is target/doc/<package>).
     --check-http            Check 'http' and 'https' scheme links.
+    --ignore-fragments      Don't check URL fragments.
     --no-build              Do not call `cargo doc` before running link checking. By default, deadlinks will call `cargo doc` if `--dir` is not passed.
     --debug                 Use debug output. This option is deprecated; use `RUST_LOG=debug` instead.
     -v --verbose            Use verbose output. This option is deprecated; use `RUST_LOG==info` instead.
@@ -34,6 +35,7 @@ struct MainArgs {
     flag_debug: bool,
     flag_check_http: bool,
     flag_no_build: bool,
+    flag_ignore_fragments: bool,
 }
 
 impl From<&MainArgs> for CheckContext {
@@ -41,6 +43,7 @@ impl From<&MainArgs> for CheckContext {
         CheckContext {
             check_http: args.flag_check_http,
             verbose: args.flag_debug,
+            check_fragments: !args.flag_ignore_fragments,
         }
     }
 }

--- a/src/bin/deadlinks.rs
+++ b/src/bin/deadlinks.rs
@@ -16,6 +16,7 @@ Usage:
 Options:
     -h --help               Print this message
     --check-http            Check 'http' and 'https' scheme links
+    --ignore-fragments      Don't check URL fragments.
     --debug                 Use debug output
     -v --verbose            Use verbose output
     -V --version            Print version info and exit.
@@ -27,6 +28,7 @@ struct MainArgs {
     flag_verbose: bool,
     flag_debug: bool,
     flag_check_http: bool,
+    flag_ignore_fragments: bool,
 }
 
 impl From<MainArgs> for CheckContext {
@@ -34,6 +36,7 @@ impl From<MainArgs> for CheckContext {
         CheckContext {
             check_http: args.flag_check_http,
             verbose: args.flag_debug,
+            check_fragments: !args.flag_ignore_fragments,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,21 @@ mod check;
 mod parse;
 
 // NOTE: this could be Copy, but we intentionally choose not to guarantee that.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct CheckContext {
     pub check_http: bool,
     pub verbose: bool,
+    pub check_fragments: bool,
+}
+
+impl Default for CheckContext {
+    fn default() -> Self {
+        CheckContext {
+            check_http: false,
+            verbose: false,
+            check_fragments: true,
+        }
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This adds `--ignore-fragments` parameter to the command line, when
specified no fragment checking will be performed.

@jyn514, this is my first quick pass at this, happy to incorporate any suggestions you might have.