### PR TITLE
CheckContext -> &CheckContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## NEXT (UNRELEASED)
 
+#### Changed
+
+* `walk_dir` now takes `&CheckContext`, not `CheckContext`. [PR#118]
+
+[PR#118]: https://github.com/deadlinks/cargo-deadlinks/pull/118
+
 <a name="0.6.2"></a>
 ## 0.6.2 (2020-11-27)
 

--- a/src/bin/cargo-deadlinks.rs
+++ b/src/bin/cargo-deadlinks.rs
@@ -127,7 +127,7 @@ fn main() {
             }
         };
         log::info!("checking directory {:?}", dir);
-        if walk_dir(&dir, ctx.clone()) {
+        if walk_dir(&dir, &ctx) {
             errors = true;
         }
     }

--- a/src/bin/deadlinks.rs
+++ b/src/bin/deadlinks.rs
@@ -83,7 +83,7 @@ fn main() {
             }
         };
         log::info!("checking directory {:?}", dir);
-        errors |= walk_dir(&dir, ctx.clone());
+        errors |= walk_dir(&dir, &ctx);
     }
     if errors {
         process::exit(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,14 +50,14 @@ impl fmt::Display for FileError {
 ///
 /// For each error that occurred, print an error message.
 /// Returns whether an error occurred.
-pub fn walk_dir(dir_path: &Path, ctx: CheckContext) -> bool {
+pub fn walk_dir(dir_path: &Path, ctx: &CheckContext) -> bool {
     let pool = ThreadPoolBuilder::new()
         .num_threads(num_cpus::get())
         .build()
         .unwrap();
 
     pool.install(|| {
-        unavailable_urls(dir_path, &ctx)
+        unavailable_urls(dir_path, ctx)
             .map(|err| {
                 if ctx.verbose {
                     println!("{}", err);


### PR DESCRIPTION
Closes #117.

This is a breaking change and should wait until https://github.com/deadlinks/cargo-deadlinks/pull/116 is merged I think.