### PR TITLE
Don't assume `/` is the directory separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 #### Fixed
 
 * Warnings from cargo are no longer silenced when documenting. [PR#114]
+* `cargo deadlinks` no longer ignores all directories on Windows. [PR#121]
 
 [PR#114]: https://github.com/deadlinks/cargo-deadlinks/pull/114
+[PR#121]: https://github.com/deadlinks/cargo-deadlinks/pull/121
 
 <a name="0.6.1"></a>
 ## 0.6.1 (2020-11-23)

--- a/src/bin/cargo-deadlinks.rs
+++ b/src/bin/cargo-deadlinks.rs
@@ -157,14 +157,11 @@ fn determine_dir(no_build: bool) -> Vec<PathBuf> {
             _ => None,
         })
         .flatten()
-        .filter_map(|dir| {
-            dir.to_str()
-                .expect("non UTF-8 paths are not supported when building documentation with Cargo")
-                .strip_suffix("/index.html")
-                // needed in order to keep a streaming iterator
-                .map(|s| s.to_owned())
+        .filter(|path| path.file_name().and_then(|f| f.to_str()) == Some("index.html"))
+        .map(|mut path| {
+            path.pop();
+            path
         })
-        .map(|s| s.into())
         // TODO: run this in parallel, which should speed up builds a fair bit.
         // This will be hard because either cargo's progress bar will overlap with our output,
         // or we'll have to recreate the progress bar somehow.


### PR DESCRIPTION
Hopefully fixes https://github.com/deadlinks/cargo-deadlinks/issues/119, waiting on someone with a windows machine to test.