### PR TITLE
Use 404 pages on example.com instead of a non-existent DNS

### DIFF
--- a/tests/non_existent_http_link/src/lib.rs
+++ b/tests/non_existent_http_link/src/lib.rs
@@ -1,6 +1,6 @@
 /// Foo function
 ///
-/// Has something to do with [some website](http://thiswebsitedoesnotexist.xyz).
+/// Has something to do with [some website](http://example.com/this/does/not/exist).
 pub fn foo() {}
 
 /// Bar function


### PR DESCRIPTION
On ISPs that 'helpfully' redirect requests to a website with a
non-existent DNS, the test would previously fail, since the page
returned 200, not 404. Use a non-existent page on example.com instead,
which should hopefully be more resilient to malicious/unthinking actors.