### PR TITLE
Update ureq, handling 307/308 redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,11 @@
 #### Fixed
 
 * Fragment errors are now shortened to use the directory being checked as the base, the same as normal 'file not found errors'. [PR#127]
+* 307 and 308 redirects are now followed. Previously, they would erroneously be reported as an error. [PR#129]
 
 [PR#118]: https://github.com/deadlinks/cargo-deadlinks/pull/118
 [PR#127]: https://github.com/deadlinks/cargo-deadlinks/pull/127
+[PR#129]: https://github.com/deadlinks/cargo-deadlinks/pull/129
 
 <a name="0.6.2"></a>
 ## 0.6.2 (2020-11-27)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,12 +58,6 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -919,11 +913,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
+checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
 dependencies = [
- "base64 0.12.3",
+ "base64",
  "log",
  "ring",
  "sct",
@@ -1199,11 +1193,11 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "1.5.2"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a599426c7388ab189dfd0eeb84c8d879490abc73e3e62a0b6a40e286f6427ab7"
+checksum = "294b85ef5dbc3670a72e82a89971608a1fcc4ed5c7c5a2895230d31a95f0569b"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "chunked_transfer",
  "log",
  "once_cell",
@@ -1334,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
+checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
  "webpki",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ num_cpus = "1.8"
 once_cell = "1.5.1"
 rayon = "1.0"
 regex = { version = "1", default-features = false, features = ["std", "perf"] }
-ureq = { version = "1.5.2", features = ["tls"], default-features = false }
+ureq = { version = "1.5.4", features = ["tls"], default-features = false }
 serde = "1.0"
 serde_derive = "1.0"
 url = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+//! <https://tinyurl.com/rnxcavf>
 use std::{
     fmt,
     path::{Path, PathBuf},

--- a/tests/working_http_check/src/lib.rs
+++ b/tests/working_http_check/src/lib.rs
@@ -1,6 +1,8 @@
 /// Foo function
 ///
 /// Has something to do with [some website](http://example.com).
+///
+/// Should also follow 308 redirects: <https://tinyurl.com/rnxcavf>
 pub fn foo() {}
 
 /// Bar function


### PR DESCRIPTION
Closes https://github.com/deadlinks/cargo-deadlinks/issues/110.