### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## NEXT (UNRELEASED)
 
+<a name="0.7.1"></a>
+## 0.7.1 (2020-12-18)
+
 #### Fixed
 
 * HTML `<meta>` redirects are now followed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-deadlinks"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_cmd",
  "cached",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-deadlinks"
 description = "Cargo subcommand for checking your documentation for broken links"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Maximilian Goisser <goisser94@gmail.com>", "Joshua Nelson <jyn514@gmail.com"]
 edition = "2018"
 repository = "https://github.com/deadlinks/cargo-deadlinks"


### PR DESCRIPTION
The only change in this release is to follow HTML `<meta>` redirects.