### PR TITLE
Switch to ureq 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
 
 * `CheckError` now has an `HttpForbidden` variant. [PR#138]
 * The `check_http` field of `CheckContext` is now an enum instead of a boolean [PR#138]
+* ureq has been upgraded to 2.0. This affects the public `CheckError` API, but should otherwise have no user-facing impact. [PR#134]
 
+[PR#134]: https://github.com/deadlinks/cargo-deadlinks/pull/134
 [PR#138]: https://github.com/deadlinks/cargo-deadlinks/pull/138
 
 <a name="0.7.2"></a>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,15 +681,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1383dff4092fe903ac180e391a8d4121cc48f08ccf850614b0290c6673b69d"
 
 [[package]]
-name = "qstring"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,15 +1185,14 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "1.5.4"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294b85ef5dbc3670a72e82a89971608a1fcc4ed5c7c5a2895230d31a95f0569b"
+checksum = "96014ded8c85822677daee4f909d18acccca744810fd4f8ffc492c284f2324bc"
 dependencies = [
  "base64",
  "chunked_transfer",
  "log",
  "once_cell",
- "qstring",
  "rustls",
  "url",
  "webpki",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ num_cpus = "1.8"
 once_cell = "1.5.1"
 rayon = "1.0"
 regex = { version = "1", default-features = false, features = ["std", "perf"] }
-ureq = { version = "1.5.4", features = ["tls"], default-features = false }
+ureq = { version = "2.0.1", features = ["tls"], default-features = false }
 serde = "1.0"
 serde_derive = "1.0"
 url = "2"

--- a/tests/non_existent_http_link.rs
+++ b/tests/non_existent_http_link.rs
@@ -1,6 +1,7 @@
 extern crate assert_cmd;
 
 use assert_cmd::prelude::*;
+use predicates::str::contains;
 use std::process::Command;
 
 mod non_existent_http_link {
@@ -40,6 +41,9 @@ mod non_existent_http_link {
             .args(&["deadlinks", "--check-http"])
             .current_dir("./tests/non_existent_http_link")
             .assert()
-            .failure();
+            .failure()
+            .stdout(contains(
+                "Unexpected HTTP status fetching http://example.com/this/does/not/exist: Not Found",
+            ));
     }
 }


### PR DESCRIPTION
Congrats to @jsha and @algestan on the release :tada: The new code is shorter and even gets rid of a dependency :)

This is a breaking change since deadlinks has `ureq::Transport` in the public API.