### PR TITLE
Promote 'skip checking' message to a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 
 [PR#136]: https://github.com/deadlinks/cargo-deadlinks/pull/136
 
+#### Changed
+
+* Give a warning when HTTP links are present but `--check-http` wasn't passed. Previously this was only a DEBUG message.
+  Note that this still requires opting-in to warnings with `RUST_LOG=warn`. [PR#137]
+
+[PR#137]: https://github.com/deadlinks/cargo-deadlinks/pull/137
+
 <a name="0.7.1"></a>
 ## 0.7.1 (2020-12-18)
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -273,7 +273,7 @@ fn handle_response(url: &Url, resp: ureq::Response) -> Result<ureq::Response, Ch
 /// Check a URL with "http" or "https" scheme for availability. Returns `false` if it is unavailable.
 fn check_http_url(url: &Url, ctx: &CheckContext) -> Result<(), CheckError> {
     if !ctx.check_http {
-        debug!(
+        warn!(
             "Skip checking {} as checking of http URLs is turned off",
             url
         );
@@ -282,7 +282,7 @@ fn check_http_url(url: &Url, ctx: &CheckContext) -> Result<(), CheckError> {
 
     for blacklisted_prefix in PREFIX_BLACKLIST.iter() {
         if url.as_str().starts_with(blacklisted_prefix) {
-            debug!(
+            warn!(
                 "Skip checking {} as URL prefix is on the builtin blacklist",
                 url
             );


### PR DESCRIPTION
Example output:

```
$ RUST_LOG=warn cargo deadlinks
[2021-01-08T15:21:18Z WARN  cargo_deadlinks::check] Skip checking http://example.com/ as checking of http URLs is turned off
[2021-01-08T15:21:18Z WARN  cargo_deadlinks::check] Skip checking https://play.rust-lang.org/ as checking of http URLs is turned off
[2021-01-08T15:21:18Z WARN  cargo_deadlinks::check] Skip checking
https://tinyurl.com/rnxcavf as checking of http URLs is turned off
```

@hobofan is this what you were imagining for https://github.com/deadlinks/cargo-deadlinks/issues/44 ? Or did you want it to be an unconditional warning? I kind of like that it's opt-in, but I could be convinced otherwise.

Closes #44