### PR TITLE
Fix simple_project test when top-level directory is not named `cargo-deadlinks`

### DIFF
--- a/tests/simple_project.rs
+++ b/tests/simple_project.rs
@@ -111,13 +111,9 @@ mod simple_project {
             .assert()
             .failure()
             .stdout(
-                contains(
-                    "cargo-deadlinks/tests/simple_project/ta\
-                  rget/doc/simple_project/fn.foo.html:",
-                )
-                .and(contains(
-                    "cargo-deadlinks/tests/simple_proj\
-                    ect/target/doc/simple_project/fn.bar.html does not exist!",
+                contains("tests/simple_project/target/doc/simple_project/fn.foo.html:")
+                    .and(contains(
+                    "tests/simple_project/target/doc/simple_project/fn.bar.html does not exist!",
                 )),
             );
     }


### PR DESCRIPTION
Make the test independent from the directory in which the repository is checked out.

Fixes #148