### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
+          toolchain: stable
           command: install
           args: cargo-sweep
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+tests/working_http_check/target2/
 tests/simple_project/target2/
 target
 Cargo.lock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ pub fn unavailable_urls<'a>(
         .into_iter()
         .par_bridge()
         .filter_map(Result::ok)
-        .filter(|entry| entry.file_type().is_file() && is_html_file(&entry))
+        .filter(|entry| entry.file_type().is_file() && is_html_file(entry))
         .flat_map(move |entry| {
             let path = entry.path();
             info!("Checking doc page at {}", path.display());
@@ -142,7 +142,7 @@ pub fn unavailable_urls<'a>(
             };
             let errors = urls
                 .into_iter()
-                .filter_map(|url| is_available(&url, &ctx).err())
+                .filter_map(|url| is_available(&url, ctx).err())
                 .chain(broken_intra_doc_links)
                 .collect::<Vec<_>>();
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -14,7 +14,7 @@ pub fn broken_intra_doc_links(html: &str) -> Vec<CheckError> {
     static BROKEN_INTRA_DOC_LINK: Lazy<Regex> =
         Lazy::new(|| Regex::new(r#"\[<code>(.*)</code>\]"#).unwrap());
     BROKEN_INTRA_DOC_LINK
-        .captures_iter(&html)
+        .captures_iter(html)
         .map(|captures| CheckError::IntraDocLink(captures.get(0).unwrap().as_str().to_owned()))
         .collect()
 }
@@ -40,7 +40,7 @@ pub fn parse_a_hrefs(html: &str, root_url: &Url, file_url: &Url) -> HashSet<Url>
                     (&file_url, href.as_str())
                 };
 
-                if let Ok(link) = base.join(&href) {
+                if let Ok(link) = base.join(href) {
                     debug!("link is {:?}", link);
                     urls.insert(link);
                 } else {

--- a/tests/working_http_check.rs
+++ b/tests/working_http_check.rs
@@ -8,9 +8,8 @@ use std::process::Command;
 mod working_http_check {
     use super::*;
 
-    #[test]
-    fn works() {
-        match std::fs::remove_dir_all("./tests/working_http_check/target") {
+    fn remove_target(relative_path: &'static str) {
+        match std::fs::remove_dir_all(&format!("./tests/working_http_check/{}", relative_path)) {
             Ok(_) => {}
             Err(err) => match err.kind() {
                 std::io::ErrorKind::NotFound => {}
@@ -19,8 +18,12 @@ mod working_http_check {
                     err
                 ),
             },
-        };
+        }
+    }
 
+    #[test]
+    fn works() {
+        remove_target("target");
         // generate docs
         Command::new("cargo")
             .arg("doc")
@@ -39,9 +42,16 @@ mod working_http_check {
 
     #[test]
     fn forbid_checking() {
+        remove_target("target2");
         Command::cargo_bin("cargo-deadlinks")
             .unwrap()
-            .args(&["deadlinks", "--forbid-http"])
+            .args(&[
+                "deadlinks",
+                "--forbid-http",
+                "--",
+                "--target-dir",
+                "target2",
+            ])
             .current_dir("./tests/working_http_check")
             .assert()
             .failure()


### PR DESCRIPTION
- Fix clippy warnings
- Fix MSRV task to use latest stable to install `cargo-sweep`

  Before, it would use the lower version to install, which broke when cargo-sweep updated its own MSRV.
- Fix tests not to conflict with one another
    
They were using the same target directory, which caused them to fail for some reason.
I expect this is related to https://github.com/rust-lang/cargo/pull/8640 somehow but it doesn't seem worth investigating.