### PR TITLE
add TARGET env var to select target for tests

### DIFF
--- a/tests/simple_project.rs
+++ b/tests/simple_project.rs
@@ -78,12 +78,10 @@ mod simple_project {
         remove_all("./tests/simple_project/target2");
         assert_doc("./tests/simple_project", &[("CARGO_TARGET_DIR", "target2")]).success();
 
+        let target: &str = option_env!("TARGET").unwrap_or("x86_64-unknown-linux-gnu");
+
         remove_all("./tests/simple_project/target");
-        assert_doc(
-            "./tests/simple_project",
-            &[("CARGO_BUILD_TARGET", "x86_64-unknown-linux-gnu")],
-        )
-        .success();
+        assert_doc("./tests/simple_project", &[("CARGO_BUILD_TARGET", target)]).success();
 
         // fn it_shortens_path_on_error
         remove_all("./tests/simple_project/target");


### PR DESCRIPTION
I maintain the `cargo-deadlinks` package for NixOS; and as part of the packaging the tests get run to ensure the correct linkage.  This tests adds an ignore flag for the `it_checks_okay_project_correctly` test when the target is not `x86_64-unknown-linux-gnu`, which allows the tests to be run on other architectures.