### PR TITLE
Update insecure dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,12 +246,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if 1.0.0",
- "lazy_static",
 ]
 
 [[package]]
@@ -285,12 +284,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "difflib"
@@ -532,13 +525,12 @@ dependencies = [
 
 [[package]]
 name = "mockito"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10030163d67f681db11810bc486df3149e6d91c8b4f3f96fa8b62b546c2cef8"
+checksum = "401edc088069634afaa5f4a29617b36dba683c0c16fe4435a86debad23fa2f1a"
 dependencies = [
  "assert-json-diff",
  "colored",
- "difference",
  "httparse",
  "lazy_static",
  "log",
@@ -546,6 +538,7 @@ dependencies = [
  "regex",
  "serde_json",
  "serde_urlencoded",
+ "similar",
 ]
 
 [[package]]
@@ -883,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -900,9 +893,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "ring"
@@ -1049,6 +1042,12 @@ dependencies = [
  "nodrop",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "similar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,4 @@ walkdir = "2.1"
 [dev-dependencies]
 assert_cmd = "2.0"
 predicates = "2.0.3"
-mockito = "0.30.0"
+mockito = "0.31.0"

--- a/src/bin/cargo-deadlinks.rs
+++ b/src/bin/cargo-deadlinks.rs
@@ -199,8 +199,7 @@ fn determine_dir(
             .packages
             .into_iter()
             .filter(|package| package.source.is_none())
-            .map(|package| package.targets)
-            .flatten()
+            .flat_map(|package| package.targets)
             .filter(has_docs)
             .map(move |target| doc.join(target.name.replace('-', "_")));
         return iter.collect();
@@ -214,6 +213,7 @@ fn determine_dir(
     });
     // Stolen from https://docs.rs/cargo_metadata/0.12.0/cargo_metadata/#examples
     let mut cargo_process = Command::new(cargo);
+    #[allow(clippy::needless_borrow)] // MSRV is 1.46
     cargo_process
         .args(&[
             "doc",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-//! <https://tinyurl.com/rnxcavf>
+#![allow(clippy::result_large_err)]
+
 use std::{
     fmt,
     path::{Path, PathBuf},
@@ -95,7 +96,7 @@ impl FileError {
     fn shorten_all(&mut self, prefix: &Path) {
         use check::Link;
 
-        if let Ok(shortened) = self.path.strip_prefix(&prefix) {
+        if let Ok(shortened) = self.path.strip_prefix(prefix) {
             self.path = shortened.to_path_buf();
         };
         for mut e in &mut self.errors {

--- a/tests/non_existent_http_link.rs
+++ b/tests/non_existent_http_link.rs
@@ -38,7 +38,7 @@ mod non_existent_http_link {
         // fails with --check-http flag
         Command::cargo_bin("cargo-deadlinks")
             .unwrap()
-            .args(&["deadlinks", "--check-http"])
+            .args(["deadlinks", "--check-http"])
             .current_dir("./tests/non_existent_http_link")
             .assert()
             .failure()

--- a/tests/working_http_check.rs
+++ b/tests/working_http_check.rs
@@ -9,7 +9,7 @@ mod working_http_check {
     use super::*;
 
     fn remove_target(relative_path: &'static str) {
-        match std::fs::remove_dir_all(&format!("./tests/working_http_check/{}", relative_path)) {
+        match std::fs::remove_dir_all(format!("./tests/working_http_check/{}", relative_path)) {
             Ok(_) => {}
             Err(err) => match err.kind() {
                 std::io::ErrorKind::NotFound => {}
@@ -34,7 +34,7 @@ mod working_http_check {
         // succeeds with --check-http flag
         Command::cargo_bin("cargo-deadlinks")
             .unwrap()
-            .args(&["deadlinks", "--check-http"])
+            .args(["deadlinks", "--check-http"])
             .current_dir("./tests/working_http_check")
             .assert()
             .success();
@@ -45,7 +45,7 @@ mod working_http_check {
         remove_target("target2");
         Command::cargo_bin("cargo-deadlinks")
             .unwrap()
-            .args(&[
+            .args([
                 "deadlinks",
                 "--forbid-http",
                 "--",


### PR DESCRIPTION
Fixes https://github.com/deadlinks/cargo-deadlinks/issues/155

```
; cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 470 security advisories (from /home/jnelson/.local/lib/cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (146 crate dependencies)
Crate:     regex
Version:   1.5.4
Title:     Regexes with large repetitions on empty sub-expressions take a very long time to parse
Date:      2022-03-08
ID:        RUSTSEC-2022-0013
URL:       https://rustsec.org/advisories/RUSTSEC-2022-0013
Solution:  Upgrade to >=1.5.5
Dependency tree:
regex 1.5.4
├── predicates 2.0.3
│   ├── cargo-deadlinks 0.8.1
│   └── assert_cmd 2.0.2
│       └── cargo-deadlinks 0.8.1
├── mockito 0.30.0
│   └── cargo-deadlinks 0.8.1
├── env_logger 0.9.0
│   └── cargo-deadlinks 0.8.1
└── cargo-deadlinks 0.8.1

Crate:     difference
Version:   2.0.0
Warning:   unmaintained
Title:     difference is unmaintained
Date:      2020-12-20
ID:        RUSTSEC-2020-0095
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0095
Dependency tree:
difference 2.0.0
└── mockito 0.30.0
    └── cargo-deadlinks 0.8.1

Crate:     crossbeam-utils
Version:   0.8.5
Warning:   yanked
Dependency tree:
crossbeam-utils 0.8.5
├── rayon-core 1.9.1
│   └── rayon 1.5.1
│       └── cargo-deadlinks 0.8.1
├── crossbeam-epoch 0.9.5
│   └── crossbeam-deque 0.8.1
│       ├── rayon-core 1.9.1
│       └── rayon 1.5.1
├── crossbeam-deque 0.8.1
└── crossbeam-channel 0.5.1
    └── rayon-core 1.9.1
```

```
; cargo update -p mockito -p regex -p crossbeam-utils
    Updating crates.io index
    Updating crossbeam-utils v0.8.5 -> v0.8.14
    Removing difference v2.0.0
    Updating mockito v0.30.0 -> v0.31.0
    Updating regex v1.5.4 -> v1.7.0
    Updating regex-syntax v0.6.25 -> v0.6.28
      Adding similar v2.2.1
```